### PR TITLE
Make indexID configurable

### DIFF
--- a/client.go
+++ b/client.go
@@ -130,7 +130,7 @@ func (c *Client) send(buf *bytes.Buffer) (int, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), c.cfg.Timeout)
 	defer cancel()
 
-	url := c.cfg.URL + "/api/v1/test/ingest?commit=" + string(c.cfg.Commit)
+	url := fmt.Sprintf("%s/api/v1/%s/ingest?commit=%s", string(c.cfg.Commit), c.cfg.IndexID, c.cfg.URL)
 
 	req, err := http.NewRequestWithContext(ctx, "POST", url, buf)
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -26,6 +26,10 @@ func New(cfg Config) *Client {
 		panic("missing Quickwit URL")
 	}
 
+	if cfg.IndexID == "" {
+		panic("missing Quickwit Index ID")
+	}
+
 	if cfg.BatchWait < 0 {
 		panic("wrong BatchWait option")
 	}
@@ -56,8 +60,8 @@ func New(cfg Config) *Client {
 }
 
 // NewWithDefault creates a new client with default configuration.
-func NewWithDefault(url string) *Client {
-	return New(NewDefaultConfig(url))
+func NewWithDefault(url string, indexID string) *Client {
+	return New(NewDefaultConfig(url, indexID))
 }
 
 func (c *Client) run() {

--- a/client.go
+++ b/client.go
@@ -130,7 +130,7 @@ func (c *Client) send(buf *bytes.Buffer) (int, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), c.cfg.Timeout)
 	defer cancel()
 
-	url := fmt.Sprintf("%s/api/v1/%s/ingest?commit=%s", string(c.cfg.Commit), c.cfg.IndexID, c.cfg.URL)
+	url := fmt.Sprintf("%s/api/v1/%s/ingest?commit=%s", c.cfg.URL, c.cfg.IndexID, string(c.cfg.Commit))
 
 	req, err := http.NewRequestWithContext(ctx, "POST", url, buf)
 	if err != nil {

--- a/config.go
+++ b/config.go
@@ -18,6 +18,8 @@ const (
 	DefaultBatchBytes int           = 10 * 1024 * 1024 // 10 MB
 	DefautCommitMode                = Auto
 
+	DefaultIndexID = "test"
+
 	DefaultMinBackoff time.Duration = 500 * time.Millisecond
 	DefaultMaxBackoff time.Duration = 5 * time.Minute
 	DefaultMaxRetries int           = 5
@@ -29,6 +31,8 @@ const (
 type Config struct {
 	URL    string
 	Client http.Client
+
+	IndexID string
 
 	BatchWait  time.Duration
 	BatchBytes int
@@ -43,6 +47,8 @@ func NewDefaultConfig(url string) Config {
 	return Config{
 		URL:    url,
 		Client: http.Client{},
+
+		IndexID: DefaultIndexID,
 
 		BatchWait:  DefaultBatchWait,
 		BatchBytes: DefaultBatchBytes,

--- a/config.go
+++ b/config.go
@@ -18,8 +18,6 @@ const (
 	DefaultBatchBytes int           = 10 * 1024 * 1024 // 10 MB
 	DefautCommitMode                = Auto
 
-	DefaultIndexID = "test"
-
 	DefaultMinBackoff time.Duration = 500 * time.Millisecond
 	DefaultMaxBackoff time.Duration = 5 * time.Minute
 	DefaultMaxRetries int           = 5
@@ -43,12 +41,12 @@ type Config struct {
 }
 
 // NewDefaultConfig creates a default configuration for a given Quickwit cluster.
-func NewDefaultConfig(url string) Config {
+func NewDefaultConfig(url string, indexID string) Config {
 	return Config{
 		URL:    url,
 		Client: http.Client{},
 
-		IndexID: DefaultIndexID,
+		IndexID: indexID,
 
 		BatchWait:  DefaultBatchWait,
 		BatchBytes: DefaultBatchBytes,

--- a/example/example.go
+++ b/example/example.go
@@ -14,7 +14,7 @@ func main() {
 	//     -H 'Content-Type: application/yaml' \
 	//     --data-binary @test-config.yaml
 
-	client := quickwit.NewWithDefault("http://localhost:7280")
+	client := quickwit.NewWithDefault("http://localhost:7280", "test")
 	defer client.Stop() // flush and stop
 
 	for i := 0; i < 10; i++ {


### PR DESCRIPTION
To not be forced into using an index with name "test", I added it to the config.